### PR TITLE
Dont need to be using BufRead file for the generic type of the VM eve…

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -16,7 +16,7 @@ fn interpreter_throughput(c: &mut Criterion) {
 
     c.bench_function("hello_world", |b| {
         b.iter(|| {
-            let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+            let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
                 .set_program(
                     Program::new(Cursor::new(program_string)).expect("Failed creating program"),
                 )
@@ -34,7 +34,7 @@ fn fixed_memory(c: &mut Criterion) {
     let program_string = ">".repeat(30000 - 1) + "+";
     c.bench_function("fixed_memory", |b| {
         b.iter(|| {
-            let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+            let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
                 .set_program(
                     Program::new(Cursor::new(black_box(&program_string)))
                         .expect("Failed creating program"),
@@ -53,7 +53,7 @@ fn memory_growth(c: &mut Criterion) {
     let program_string = ">".repeat(120000 - 3) + "+";
     c.bench_function("memory_growth", |b| {
         b.iter(|| {
-            let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+            let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
                 .set_program(
                     Program::new(Cursor::new(black_box(&program_string)))
                         .expect("Failed creating program"),
@@ -72,7 +72,7 @@ fn nested_loops(c: &mut Criterion) {
         "[[[[[[[[[[-]>]>>>>]<<<<<<]>>>>>>]<<<<<<<<<]>>>>>>>>>]<<<<<<<<<<]>>>>>>>>>>>]<<<<<<<<<<<]";
     c.bench_function("nested_loops", |b| {
         b.iter(|| {
-            let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+            let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
                 .set_program(
                     Program::new(Cursor::new(black_box(&program_string)))
                         .expect("Failed creating program"),
@@ -90,7 +90,7 @@ fn long_program(c: &mut Criterion) {
     // Using NullWriter because this program spits loads of stuff out
     c.bench_function("long_program", |b| {
         b.iter(|| {
-            let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, NullWriter>::new()
+            let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, NullWriter>::new()
                 .set_program_file(BufReader::new(
                     File::open("benches/fib.bf").expect("Could not find file"),
                 ))

--- a/bft_interp/src/vm.rs
+++ b/bft_interp/src/vm.rs
@@ -361,11 +361,7 @@ mod vm_tests {
     use env_logger;
     use log::LevelFilter;
     use rand::Rng;
-    use std::{
-        fs::File,
-        io::{BufReader, Cursor},
-        num::NonZeroUsize,
-    };
+    use std::{io::Cursor, num::NonZeroUsize};
 
     // Setup logging for any tests that it might be useful for
     pub fn setup_logging() {
@@ -388,7 +384,7 @@ mod vm_tests {
                 instruction: HumanReadableInstruction::undefined(),
                 reason: "Failed creating new test Program".to_string(),
             })?;
-        let vm = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+        let vm = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
             .set_program(program)
             .set_cell_count(cell_count)
             .set_allow_growth(allow_growth) // default or test-specific value
@@ -404,7 +400,7 @@ mod vm_tests {
     ) -> Result<BrainfuckVM<u8>, Box<dyn std::error::Error>> {
         let testfile = TestFile::new()?;
         let program = Program::new(testfile)?;
-        let vm = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
+        let vm = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
             .set_program(program)
             .set_allow_growth(allow_growth)
             .set_cell_count(cell_count)


### PR DESCRIPTION
Previously I had been using BufReader<File> as the Read generic type when creating a VM, probably because I was getting confused between the Programs Read type

Change it to stdin, since thats the default anyway