### PR TITLE
Should only have set_program_reader and set_program_file

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,7 +1,6 @@
-use std::fs::File;
-use std::io::BufReader;
 use std::io::Cursor;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 
 use bft_interp::vm::BrainfuckVM;
 use bft_interp::vm_builder::VMBuilder;
@@ -17,9 +16,7 @@ fn interpreter_throughput(c: &mut Criterion) {
     c.bench_function("hello_world", |b| {
         b.iter(|| {
             let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-                .set_program(
-                    Program::new(Cursor::new(program_string)).expect("Failed creating program"),
-                )
+                .set_program_reader(Cursor::new(program_string))
                 .set_cell_count(NonZeroUsize::new(30000))
                 .build()
                 .unwrap();
@@ -35,10 +32,7 @@ fn fixed_memory(c: &mut Criterion) {
     c.bench_function("fixed_memory", |b| {
         b.iter(|| {
             let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-                .set_program(
-                    Program::new(Cursor::new(black_box(&program_string)))
-                        .expect("Failed creating program"),
-                )
+                .set_program_reader(Cursor::new(black_box(&program_string)))
                 .set_allow_growth(false) // Note: `set_allow_growth(false)` for fixed memory
                 .build()
                 .unwrap();
@@ -54,10 +48,7 @@ fn memory_growth(c: &mut Criterion) {
     c.bench_function("memory_growth", |b| {
         b.iter(|| {
             let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-                .set_program(
-                    Program::new(Cursor::new(black_box(&program_string)))
-                        .expect("Failed creating program"),
-                )
+                .set_program_reader(Cursor::new(black_box(&program_string)))
                 .set_allow_growth(true)
                 .build()
                 .unwrap();
@@ -73,10 +64,7 @@ fn nested_loops(c: &mut Criterion) {
     c.bench_function("nested_loops", |b| {
         b.iter(|| {
             let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-                .set_program(
-                    Program::new(Cursor::new(black_box(&program_string)))
-                        .expect("Failed creating program"),
-                )
+                .set_program_reader(Cursor::new(black_box(&program_string)))
                 .set_allow_growth(true)
                 .build()
                 .unwrap();
@@ -91,9 +79,7 @@ fn long_program(c: &mut Criterion) {
     c.bench_function("long_program", |b| {
         b.iter(|| {
             let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, NullWriter>::new()
-                .set_program_file(BufReader::new(
-                    File::open("benches/fib.bf").expect("Could not find file"),
-                ))
+                .set_program_file(PathBuf::from("benches/fib.bf"))
                 .set_allow_growth(true)
                 .set_output(NullWriter)
                 .build()

--- a/bft_interp/src/vm.rs
+++ b/bft_interp/src/vm.rs
@@ -379,13 +379,9 @@ mod vm_tests {
         allow_growth: bool,
         cell_count: Option<NonZeroUsize>,
     ) -> Result<BrainfuckVM<u8>, VMError<u8>> {
-        let program =
-            Program::new(Cursor::new(program_string)).map_err(|_| VMError::ProgramError {
-                instruction: HumanReadableInstruction::undefined(),
-                reason: "Failed creating new test Program".to_string(),
-            })?;
+        let program_reader = Cursor::new(program_string);
         let vm = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-            .set_program(program)
+            .set_program_reader(program_reader)
             .set_cell_count(cell_count)
             .set_allow_growth(allow_growth) // default or test-specific value
             .set_report_state(true) // Need this for tests
@@ -398,10 +394,8 @@ mod vm_tests {
         allow_growth: bool,
         cell_count: Option<NonZeroUsize>,
     ) -> Result<BrainfuckVM<u8>, Box<dyn std::error::Error>> {
-        let testfile = TestFile::new()?;
-        let program = Program::new(testfile)?;
         let vm = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
-            .set_program(program)
+            .set_program_reader(TestFile::new()?)
             .set_allow_growth(allow_growth)
             .set_cell_count(cell_count)
             .set_report_state(true) // Need this for tests
@@ -696,7 +690,6 @@ mod vm_tests {
         let mut program_string = String::with_capacity(number_of_instructions);
         program_string.extend(",".repeat(number_of_instructions).chars());
         let cell_count = NonZeroUsize::new(1);
-        let program = Program::new(Cursor::new(program_string))?;
 
         // Generate some random u8 values
         let mut rng = rand::thread_rng();
@@ -705,7 +698,7 @@ mod vm_tests {
 
         let reader = Cursor::new(buffer.clone());
         let mut vm: BrainfuckVM<u8> = VMBuilder::<Cursor<Vec<u8>>, std::io::Cursor<Vec<u8>>>::new()
-            .set_program(program)
+            .set_program_reader(Cursor::new(program_string))
             .set_cell_count(cell_count)
             .set_allow_growth(false)
             .set_input(reader)
@@ -766,7 +759,6 @@ mod vm_tests {
         program_string.extend(".>".repeat(number_of_reads).chars());
         // Remove the final > so we don't go over the cell count
         program_string.pop();
-        let program = Program::new(Cursor::new(program_string))?;
         let cell_count = NonZeroUsize::new(number_of_moves);
 
         // Generate some random u8 values
@@ -778,7 +770,7 @@ mod vm_tests {
         let output_buffer: Vec<u8> = Vec::new(); // Initialize an empty Vec<u8>
         let writer = Cursor::new(output_buffer);
         let mut vm: BrainfuckVM<u8> = VMBuilder::<Cursor<Vec<u8>>, std::io::Cursor<Vec<u8>>>::new()
-            .set_program(program)
+            .set_program_reader(Cursor::new(program_string))
             .set_cell_count(cell_count)
             .set_allow_growth(false)
             .set_output(writer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,50 +3,20 @@ use clap::Parser;
 use log::LevelFilter;
 use std::any::TypeId;
 use std::error::Error;
-use std::fs::File;
-use std::io::BufReader;
 mod cli;
 use cli::Cli;
 use std::process;
-// TODO: maybe this comment should be on fn main()
-/// Entry point for the Brainfuck interpreter program.
-///
-/// This program reads a filename from the command line, loads a Brainfuck program from that file,
-/// and then interprets it using a Brainfuck virtual machine.
-///
-/// # Arguments
-///
-/// Reads command-line arguments to get the filename of the Brainfuck program to interpret.
-///
-/// # Errors
-///
-/// Returns an error if no filename is provided or if there are issues with reading or interpreting the program file.
-///
-/// # Examples
-///
-/// Run the program from the command line with:
-/// ```bash
-/// cargo run -- example.bf
-/// ```
-/// Replace `example.bf` with the path to your Brainfuck program file.
-///
-/// # Remarks
-///
-/// The Brainfuck program is interpreted by printing the instructions to the console.
-/// Future implementations may include execution of the Brainfuck program.
 
+/// Run the interpreter using CLI args
 fn run_bft(cli: Cli) -> Result<(), Box<dyn Error>> {
-    let test_log_level = LevelFilter::Info;
+    let test_log_level = LevelFilter::Warn;
     let _ = env_logger::builder()
         .is_test(true)
         .filter(None, test_log_level)
         .try_init();
 
-    let file = File::open(cli.program)?;
-    let program_file = BufReader::new(file);
-
-    let mut vm: BrainfuckVM<u8> = VMBuilder::<BufReader<File>, std::io::Stdout>::new()
-        .set_program_file(program_file)
+    let mut vm: BrainfuckVM<u8> = VMBuilder::<std::io::Stdin, std::io::Stdout>::new()
+        .set_program_file(cli.program)
         .set_allow_growth(cli.allow_growth)
         .set_cell_count(cli.cell_count)
         .set_cell_kind(TypeId::of::<u8>())
@@ -54,7 +24,6 @@ fn run_bft(cli: Cli) -> Result<(), Box<dyn Error>> {
         .build()
         .map_err(|e| format!("Error: {}", e))?;
 
-    // Use the interpret function to print the BF program
     match vm.interpret() {
         Ok(final_state) => {
             if cli.report_state {
@@ -69,6 +38,21 @@ fn run_bft(cli: Cli) -> Result<(), Box<dyn Error>> {
     }
 }
 
+/// Entry point for the interpreter program.
+///
+/// Reads a filename from the command line, loads a Brainfuck program from that file,
+/// and then interprets it using a Brainfuck virtual machine.
+///
+/// # Errors
+///
+/// Returns an error if no filename is provided or if there are issues with reading or interpreting the program file.
+///
+/// # Examples
+///
+/// Run the program from the command line with:
+/// ```bash
+/// cargo run -- test_programs/example.bf
+/// ```
 fn main() {
     let cli = Cli::parse();
 


### PR DESCRIPTION
Only just realised I confused the reader R with the input/output parts of the VM

Simplify so we only need to set_program_file or set_program_reader, making things clearer